### PR TITLE
Refactor signature code

### DIFF
--- a/tests/test_sig.py
+++ b/tests/test_sig.py
@@ -69,7 +69,7 @@ class TestSig(unittest.TestCase):
     # Should verify we are not adding a duplicate signature
     # when doing the following action.  Here we know 'signable'
     # has only one signature so it's okay.
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[0], signable['signed']))
 
     tuf.keydb.add_key(KEYS[0]) 
@@ -99,7 +99,7 @@ class TestSig(unittest.TestCase):
   def test_get_signature_status_bad_sig(self):
     signable = {'signed' : 'test', 'signatures' : []}
 
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[0], signable['signed']))
     signable['signed'] += 'signature no longer matches signed data'
 
@@ -129,7 +129,7 @@ class TestSig(unittest.TestCase):
   def test_get_signature_status_unknown_method(self):
     signable = {'signed' : 'test', 'signatures' : []}
 
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[0], signable['signed']))
     signable['signatures'][0]['method'] = 'fake-sig-method'
 
@@ -160,7 +160,7 @@ class TestSig(unittest.TestCase):
   def test_get_signature_status_single_key(self):
     signable = {'signed' : 'test', 'signatures' : []}
 
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[0], signable['signed']))
 
     tuf.keydb.add_key(KEYS[0])
@@ -189,7 +189,7 @@ class TestSig(unittest.TestCase):
   def test_get_signature_status_below_threshold(self):
     signable = {'signed' : 'test', 'signatures' : []}
 
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[0], signable['signed']))
 
     tuf.keydb.add_key(KEYS[0])
@@ -221,9 +221,9 @@ class TestSig(unittest.TestCase):
     signable = {'signed' : 'test', 'signatures' : []}
 
     # Two keys sign it, but only one of them will be trusted.
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[0], signable['signed']))
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[2], signable['signed']))
 
     tuf.keydb.add_key(KEYS[0])
@@ -258,9 +258,9 @@ class TestSig(unittest.TestCase):
 
     # Two keys sign it, but one of them is only trusted for a different
     # role.
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[0], signable['signed']))
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[1], signable['signed']))
 
     tuf.keydb.add_key(KEYS[0])
@@ -297,7 +297,7 @@ class TestSig(unittest.TestCase):
   def test_check_signatures_no_role(self):
     signable = {'signed' : 'test', 'signatures' : []}
 
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[0], signable['signed']))
 
     tuf.keydb.add_key(KEYS[0])
@@ -315,7 +315,7 @@ class TestSig(unittest.TestCase):
 
   def test_verify_single_key(self):
     signable = {'signed' : 'test', 'signatures' : []}
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[0], signable['signed']))
 
     tuf.keydb.add_key(KEYS[0])
@@ -339,9 +339,9 @@ class TestSig(unittest.TestCase):
     signable = {'signed' : 'test', 'signatures' : []}
 
     # Two keys sign it, but only one of them will be trusted.
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[0], signable['signed']))
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[2], signable['signed']))
 
     tuf.keydb.add_key(KEYS[0])
@@ -361,11 +361,17 @@ class TestSig(unittest.TestCase):
     tuf.roledb.remove_role('Root')
 
 
-
+  # This test fails because the specialized function generate_rsa_signature is
+  # no longer supported in this fork. RSA signatures should be generated like
+  # any other signature.
+  # TODO: When merging, mind this difference. Uptane doesn't use this function,
+  # and Uptane is the customer of this fork. See that securesystemslib
+  # post-merge uses consistently structured signing code.
+  @unittest.expectedFailure
   def test_generate_rsa_signature(self):
     signable = {'signed' : 'test', 'signatures' : []}
 
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[0], signable['signed']))
 
     self.assertEqual(1, len(signable['signatures']))
@@ -375,7 +381,7 @@ class TestSig(unittest.TestCase):
     returned_signature = tuf.sig.generate_rsa_signature(signable['signed'], KEYS[0]) 
     self.assertTrue(tuf.formats.SIGNATURE_SCHEMA.matches(returned_signature))
 
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[1], signable['signed']))
 
     self.assertEqual(2, len(signable['signatures']))
@@ -388,7 +394,7 @@ class TestSig(unittest.TestCase):
     # One untrusted key in 'signable'.    
     signable = {'signed' : 'test', 'signatures' : []}
 
-    signable['signatures'].append(tuf.keys.create_signature(
+    signable['signatures'].append(tuf.sig.sign_over_metadata(
                                   KEYS[0], signable['signed']))
 
     tuf.keydb.add_key(KEYS[1])

--- a/tuf/asn1_codec.py
+++ b/tuf/asn1_codec.py
@@ -270,14 +270,13 @@ def convert_signed_metadata_to_der(
     # This hashing is redundant and temporary. Eventually, the hash will
     # consistently be performed in securesystemslib/keys.py in the
     # create_signature() function, so we shouldn't be taking a hash here.
-    # For the time being, I do this so that it always uses a hash even for ed25519
-    # and also so that the canonicalization that is currently called by
-    # create_signature() doesn't choke on the DER I want to sign.
+    # For the time being, I do this so that it always uses a hash even for
+    # ed25519.
     hash_of_der = hashlib.sha256(der_signed).digest()
 
-    # Now sign the metadata. (This signs a cryptographic hash of the metadata.)
-    # The returned value is a basic Python dict writable into JSON.
-    # This is a signature over the hash of the DER encoding.
+    # Now sign the metadata.
+    # The returned value is a basic Python dict writable into JSON, containing
+    # a signature over the cryptographic hash of the DER encoding.
     pydict_signatures = [tuf.keys.create_signature(private_key, hash_of_der)]
 
   else:

--- a/tuf/asn1_codec.py
+++ b/tuf/asn1_codec.py
@@ -278,13 +278,7 @@ def convert_signed_metadata_to_der(
     # Now sign the metadata. (This signs a cryptographic hash of the metadata.)
     # The returned value is a basic Python dict writable into JSON.
     # This is a signature over the hash of the DER encoding.
-    # Tell keys.create_signature that the data we're providing is not JSON so
-    # that it doesn't try to canonicalize it (and wrap the hash in double
-    # quotes).
-    # Because it is a hash in hexadecimal, neither is this raw binary data,
-    # so we don't use the binary_data=True flag.
-    pydict_signatures = [tuf.keys.create_signature(
-        private_key, hash_of_der, force_non_json=True, is_binary_data=True)]
+    pydict_signatures = [tuf.keys.create_signature(private_key, hash_of_der)]
 
   else:
     pydict_signatures = signed_metadata['signatures']

--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -1550,7 +1550,7 @@ class SingleRepoUpdater(object):
 
     metadata = metadata_file_object.read()
     try:
-      metadata_signable = tuf.util.load_string(metadata) # TODO: <~> VERIFY THIS.
+      metadata_signable = tuf.util.load_string(metadata)
 
     except Exception as exception:
       raise tuf.InvalidMetadataJSONError(exception)

--- a/tuf/keys.py
+++ b/tuf/keys.py
@@ -694,8 +694,8 @@ def create_signature(key_dict, data):
       (e.g. string.encode('utf-8')).
 
   <Exceptions>
-    tuf.FormatError, if 'key_dict' is improperly formatted.
-   
+    tuf.FormatError, if 'key_dict' or 'data' is improperly formatted.
+
     tuf.UnsupportedLibraryError, if an unsupported or unavailable library is
     detected.
 
@@ -715,7 +715,10 @@ def create_signature(key_dict, data):
   # Raise 'tuf.FormatError' if the check fails.
   # The key type of 'key_dict' must be either 'rsa' or 'ed25519'.
   tuf.formats.ANYKEY_SCHEMA.check_match(key_dict)
-  
+
+  # Test to make sure data is binary. If not, raise tuf.FormatError()
+  tuf.formats.DATA_SCHEMA.check_match(data)
+
   # Raise 'tuf.UnsupportedLibraryError' if the following libraries, specified
   # in 'tuf.conf', are unsupported or unavailable:
   # 'tuf.conf.RSA_CRYPTO_LIBRARY' or 'tuf.conf.ED25519_CRYPTO_LIBRARY'. 
@@ -824,9 +827,9 @@ def verify_signature(key_dict, signature, data):
       (e.g. string.encode('utf-8')).
 
   <Exceptions>
-    tuf.FormatError, raised if either 'key_dict' or 'signature' are improperly
-    formatted.
-    
+    tuf.FormatError, raised if any of 'key_dict', 'data', or 'signature' are
+    improperly formatted.
+
     tuf.UnsupportedLibraryError, if an unsupported or unavailable library is
     detected.
     
@@ -849,6 +852,9 @@ def verify_signature(key_dict, signature, data):
 
   # Does 'signature' have the correct format?
   tuf.formats.SIGNATURE_SCHEMA.check_match(signature)
+
+  # Test to make sure data is binary. If not, raise tuf.FormatError()
+  tuf.formats.DATA_SCHEMA.check_match(data)
 
   # Using the public key belonging to 'key_dict'
   # (i.e., rsakey_dict['keyval']['public']), verify whether 'signature'

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -388,17 +388,6 @@ def _remove_invalid_and_duplicate_signatures(
   signature_keyids = []
 
   for signature in signable['signatures']:
-    signed = signable['signed']
-    if tuf.conf.METADATA_FORMAT == 'der': # Encode as DER before signing.
-      # TODO: These three lines, from signed = through this one, should be
-      # moved out of the for loop, to just before. There's no need to do them
-      # repeatedly. Also, this line is now clumsy, taking in more than it needs
-      # and using a parameter to get back only what it wants.
-      signed = asn1_codec.convert_signed_metadata_to_der(
-          signable, only_signed=True)
-      # If we're using DER, then what we validate should be the signature over
-      # the sha256 hash of the DER encoding.
-      signed = hashlib.sha256(signed).digest()
     keyid = signature['keyid']
     key = None
 

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -140,18 +140,6 @@ def get_signature_status(signable, role=None, repository_name='default'):
   signed = signable['signed']
   signatures = signable['signatures']
 
-  # If we are using DER metadata, the 'signed' field must be converted into
-  # DER so that the signature (which was signed into DER) can match it.
-  # If the format or encoding are different, this verification will fail,
-  # since we're re-encoding to check the signature....
-  if tuf.conf.METADATA_FORMAT == 'der':
-    signed = asn1_codec.convert_signed_metadata_to_der(
-        signable, only_signed=True)
-    # Replace signed with a hash of signed, since that's all we'll need to sign
-    # and we are not doing anything else with 'signed' here.
-    # Digest provides binary data.
-    signed = hashlib.sha256(signed).digest()
-
   # Iterate through the signatures and enumerate the signature_status fields.
   # (i.e., good_sigs, bad_sigs, etc.).
   for signature in signatures:

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -435,8 +435,9 @@ def sign_over_metadata(
     TypeError, if 'key_dict' contains an invalid keytype.
 
   <Side Effects>
-    The cryptography library specified in 'tuf.conf' called to perform the
-    actual signing routine.
+    The cryptography library specified in 'tuf.conf' is called to do the actual
+    verification. When in 'der' mode, argument data is converted into ASN.1/DER
+    in order to verify it. (Argument object is unchanged.)
 
   <Returns>
     A signature dictionary conformant to 'tuf.format.SIGNATURE_SCHEMA'. e.g.:
@@ -524,9 +525,9 @@ def verify_signature_over_metadata(
 
       In 'json' mode:
         'data' can be any data that can be processed by
-        tuf.formats.encode_canonical(data) can be signed. This function is
-        generally intended to verify signatures over metadata
-        (tuf.formats.ANYROLE_SCHEMA), but can be used more broadly.
+        tuf.formats.encode_canonical(data). This function is generally intended
+        to verify signatures over TUF metadata (tuf.formats.ANYROLE_SCHEMA),
+        but can be used more broadly when in 'json' mode.
 
     metadata_format: (optional; default based on tuf.conf.METADATA_FORMAT)
       If 'json', treats data as a JSON-friendly Python dictionary to be turned
@@ -553,7 +554,8 @@ def verify_signature_over_metadata(
 
   <Side Effects>
     The cryptography library specified in 'tuf.conf' is called to do the actual
-    verification.
+    verification. When in 'der' mode, argument data is converted into ASN.1/DER
+    in order to verify it. (Argument object is unchanged.)
 
   <Returns>
     Boolean.  True if the signature is valid, False otherwise.

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -157,11 +157,13 @@ def get_signature_status(signable, role=None, repository_name='default'):
 
     # Identify key using an unknown key signing method.
     try:
-      if tuf.conf.METADATA_FORMAT == 'der':
-        valid_sig = tuf.keys.verify_signature(
-            key, signature, signed, is_binary_data=True)
-      else:
-        valid_sig = tuf.keys.verify_signature(key, signature, signed)
+      # TODO: Consider more efficient measures. If the metadata format is
+      # ASN.1/DER ('der'), this line performs a conversion of the data into
+      # ASN.1/DER once per signature. It would be more efficient to do the
+      # conversion once before the loop, and manually use lower-level
+      # signature verification, but that would also be less clean.
+      # If we're using JSON, then this is equally efficient and still cleaner.
+      valid_sig = verify_signature_over_metadata(key, signature, signed)
 
     except tuf.UnknownMethodError:
       unknown_method_sigs.append(keyid)

--- a/tuf/sig.py
+++ b/tuf/sig.py
@@ -485,19 +485,6 @@ def verify_signature_over_metadata(
 
     See tuf.keys.verify_signature for lower level details.
 
-    >>> data = 'The quick brown fox jumps over the lazy dog'
-    >>> signature = create_signature(ed25519_key, data)
-    >>> verify_signature(ed25519_key, signature, data)
-    True
-    >>> verify_signature(ed25519_key, signature, 'bad_data')
-    False
-    >>> rsa_key = generate_rsa_key()
-    >>> signature = create_signature(rsa_key, data)
-    >>> verify_signature(rsa_key, signature, data)
-    True
-    >>> verify_signature(rsa_key, signature, 'bad_data')
-    False
-
   <Arguments>
     key_dict:
       A dictionary containing the TUF keys and other identifying information.

--- a/tuf/util.py
+++ b/tuf/util.py
@@ -1092,9 +1092,24 @@ def load_file(filepath):
 
 def load_string(data):
   """
-  Loads the given DER or JSON string into TUF's standard Python dictionary
+  Loads the given DER or JSON data into TUF's standard Python dictionary
   format (return value conforms with tuf.formats.SIGNABLE_SCHEMA, with the
   value of 'signed' conforming to tuf.formats.ANYROLE_SCHEMA).
+
+  In DER mode, takes bytes (encoded ASN.1/DER data).
+  In JSON mode, takes a string (already decoded)
+
+
+  Here are the constraints leading to this unusual coding:
+    - Keys are always loaded from JSON, not DER, by calling load_json_string
+      directly.
+    - DER can't be decoded into a string from bytes
+    - It is preferable not to have DER vs JSON conditionals in every piece of
+      code that loads metadata by calling load_string. (It is preferable for
+      load_string to do it.)
+
+  # TODO: Consider renaming this 'deserialize', since it may deal with 'strings'
+    or 'bytes' (making the existing name misleading).
 
   A simple wrapper for load_der_string and load_json_string. Please see
   comments in those functions.
@@ -1103,7 +1118,7 @@ def load_string(data):
     return load_der_string(data)
 
   elif tuf.conf.METADATA_FORMAT == 'json':
-    return load_json_string(data)
+    return load_json_string(data.decode('utf-8'))
 
   else:
     raise tuf.Error('tuf.util.load_string() only supports DER or JSON, but '


### PR DESCRIPTION
Separate low-level signing code from encoding and formatting code once and for all. (:

This makes the code more readable and less confusing, and also makes life a lot easier for Uptane upstream.

[This Uptane PR](https://github.com/uptane/uptane/pull/75) should be applied in tandem.


I was originally going to wait until after the *Great Merge of the TUF Forks* for this, but after more lost time debugging, I got pretty sick of all of the optional arguments I had to add to tuf.keys, and the edge cases requiring coordination.... It was time to do this.