### PR TITLE
Descriptive json error

### DIFF
--- a/tuf/util.py
+++ b/tuf/util.py
@@ -888,10 +888,10 @@ def load_json_string(data):
   try:
     deserialized_object = json.loads(data)
 
-  except TypeError:
-    message = 'Invalid JSON string: ' + repr(data)
-    raise tuf.Error(message)
-  
+  except TypeError as e:
+    raise tuf.Error('Invalid JSON string. Error reads: {{' + repr(e) + '}}. '
+        'Data provided: ' + repr(data))
+
   except ValueError:
     message = 'Cannot deserialize to a Python object: ' + repr(data)
     raise tuf.Error(message)


### PR DESCRIPTION
Minor tweak: makes the cause of JSON load errors more visible.

Only 3c4bf4e is part of this PR.