### PR TITLE
Sane asn1 property limits

### DIFF
--- a/tuf/encoding/metadata_asn1_definitions.py
+++ b/tuf/encoding/metadata_asn1_definitions.py
@@ -46,7 +46,7 @@ class OctetString(univ.OctetString):
     pass
 
 
-OctetString.subtypeSpec = constraint.ValueSizeConstraint(1, 1024)
+OctetString.subtypeSpec = constraint.ValueSizeConstraint(0, 1024)
 
 
 class BitString(univ.BitString):
@@ -230,7 +230,7 @@ class Repositories(univ.SequenceOf):
 
 
 Repositories.componentType = Repository()
-Repositories.subtypeSpec=constraint.ValueSizeConstraint(2, 2)
+Repositories.subtypeSpec=constraint.ValueSizeConstraint(0, 1024)
 
 
 class Path(char.VisibleString):
@@ -245,7 +245,7 @@ class Paths(univ.SequenceOf):
 
 
 Paths.componentType = Path()
-Paths.subtypeSpec=constraint.ValueSizeConstraint(1, 8)
+Paths.subtypeSpec=constraint.ValueSizeConstraint(0, 1024)
 
 
 class RepositoryNames(univ.SequenceOf):
@@ -253,7 +253,7 @@ class RepositoryNames(univ.SequenceOf):
 
 
 RepositoryNames.componentType = RepositoryName()
-RepositoryNames.subtypeSpec=constraint.ValueSizeConstraint(2, 2)
+RepositoryNames.subtypeSpec=constraint.ValueSizeConstraint(0, 1024)
 
 
 class Mapping(univ.Sequence):


### PR DESCRIPTION
There are some unusual limits on the ASN.1 properties. Requirements on the number of repositories should be in high-level code, not low-level ASN.1-specific code. Empty octet strings are OK. Empty path lists are okay, and so are path lists of large size. And so on.

There are probably quite a lot more of these.