### PR TITLE
ASN1: modern pyasn1 compatibility and cleanup for ASN.1/DER conversion

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,7 +16,7 @@ cffi==1.11.5
 pycrypto==2.6.1
 pynacl==1.2.1
 cryptography==2.3
-pyasn1==0.2.2
+pyasn1==0.4.4
 
 # Testing requirements.  The rest of the testing dependencies available in
 # 'tox.ini'

--- a/tuf/asn1_codec.py
+++ b/tuf/asn1_codec.py
@@ -141,10 +141,10 @@ def convert_signed_der_to_dersigned_json(der_data):
 
   for asn_signature in asn_signatures:
     json_signatures.append({
-        'keyid': hex_from_octetstring(asn_signature['keyid']['octetString']),
+        'keyid': hex_from_octetstring(asn_signature['keyid']),
         # TODO: See if it's possible to tweak the definition of 'method' so that str(method) returns what we want rather here than the enum, so that we don't have to do make this weird enum translation call?
         'method': asn_signature['method'].namedValues[asn_signature['method']._value][0], #str(asn_signature['method']),
-        'sig': hex_from_octetstring(asn_signature['value']['octetString'])})
+        'sig': hex_from_octetstring(asn_signature['value'])})
 
   return {'signatures': json_signatures, 'signed': json_signed}
 
@@ -308,12 +308,7 @@ def convert_signed_metadata_to_der(
     # to use a class that inherits from that auto-generated class... but that's
     # quite confusing to a reader, too.
     # asn_sig['keyid'] = pydict_sig['keyid'] # <- used to just be this
-    asn_sig['keyid'] = metadata_asn1_spec.Keyid().subtype(
-        explicitTag=p_type_tag.Tag(p_type_tag.tagClassContext,
-        p_type_tag.tagFormatConstructed, 0))
-    asn_sig['keyid']['octetString'] = p_type_univ.OctetString(
-        hexValue=pydict_sig['keyid']).subtype(implicitTag=p_type_tag.Tag(
-        p_type_tag.tagClassContext, p_type_tag.tagFormatSimple, 1))
+    asn_sig['keyid'] = metadata_asn1_spec.Keyid(hexValue=pydict_sig['keyid'])
 
 
     # Because 'method' is an enum, extracting the string value is a bit messy.
@@ -327,12 +322,8 @@ def convert_signed_metadata_to_der(
     # the way to do this might be to use a class that inherits from that
     # auto-generated class... but that's quite confusing to a reader, too.
     #asn_sig['value'] = pydict_sig['sig'] # <- used to just be this
-    asn_sig['value'] = metadata_asn1_spec.BinaryData().subtype(
-        explicitTag=p_type_tag.Tag(p_type_tag.tagClassContext,
-        p_type_tag.tagFormatConstructed, 2))
-    asn_sig['value']['octetString'] = p_type_univ.OctetString(
-        hexValue=pydict_sig['sig']).subtype(implicitTag=p_type_tag.Tag(
-        p_type_tag.tagClassContext, p_type_tag.tagFormatSimple, 1))
+    asn_sig['value'] = metadata_asn1_spec.OctetString(
+        hexValue=pydict_sig['sig'])
 
 
     # Add to the Signatures() list.

--- a/tuf/asn1_codec.py
+++ b/tuf/asn1_codec.py
@@ -123,7 +123,7 @@ def convert_signed_der_to_dersigned_json(der_data):
   # We call lower() on it because I don't care about the casing, which has
   # varied somewhat in TUF history, and I don't want casing to ruin this
   # detection.
-  metadata_type = asn_type_data.namedValues[asn_type_data._value][0].lower()
+  metadata_type = asn_type_data.namedValues[asn_type_data._value].lower()
 
   # Make sure it's a supported type of metadata for ASN.1 to Python dict
   # translation. (Throw an exception if not.)
@@ -142,8 +142,10 @@ def convert_signed_der_to_dersigned_json(der_data):
   for asn_signature in asn_signatures:
     json_signatures.append({
         'keyid': hex_from_octetstring(asn_signature['keyid']),
-        # TODO: See if it's possible to tweak the definition of 'method' so that str(method) returns what we want rather here than the enum, so that we don't have to do make this weird enum translation call?
-        'method': asn_signature['method'].namedValues[asn_signature['method']._value][0], #str(asn_signature['method']),
+        # TODO: See if it's possible to tweak the definition of 'method' so
+        # that str(method) returns what we want rather here than the enum, so
+        # that we don't have to do make this weird enum translation call?
+        'method': asn_signature['method'].namedValues[asn_signature['method']._value],
         'sig': hex_from_octetstring(asn_signature['value'])})
 
   return {'signatures': json_signatures, 'signed': json_signed}

--- a/tuf/encoding/metadata_asn1_definitions.py
+++ b/tuf/encoding/metadata_asn1_definitions.py
@@ -49,23 +49,6 @@ class OctetString(univ.OctetString):
 OctetString.subtypeSpec = constraint.ValueSizeConstraint(1, 1024)
 
 
-class BitString(univ.BitString):
-    pass
-
-
-BitString.subtypeSpec=constraint.ValueSizeConstraint(1, 1024)
-
-
-class BinaryData(univ.Choice):
-    pass
-
-
-BinaryData.componentType = namedtype.NamedTypes(
-    namedtype.NamedType('bitString', BitString().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
-    namedtype.NamedType('octetString', OctetString().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1)))
-)
-
-
 class EncryptedSymmetricKeyType(univ.Enumerated):
     pass
 
@@ -83,7 +66,7 @@ class EncryptedSymmetricKey(univ.Sequence):
 
 EncryptedSymmetricKey.componentType = namedtype.NamedTypes(
     namedtype.NamedType('encryptedSymmetricKeyType', EncryptedSymmetricKeyType().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
-    namedtype.NamedType('encryptedSymmetricKeyValue', BinaryData().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)))
+    namedtype.NamedType('encryptedSymmetricKeyValue', OctetString().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)))
 )
 
 
@@ -131,9 +114,8 @@ class Hash(univ.Sequence):
 
 
 Hash.componentType = namedtype.NamedTypes(
-    namedtype.NamedType('function', HashFunction().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 0))),
-    namedtype.NamedType('digest', BinaryData().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 1)))
-)
+    namedtype.NamedType('function', HashFunction()),
+    namedtype.NamedType('digest', OctetString()))
 
 
 class Hashes(univ.SequenceOf):
@@ -176,7 +158,7 @@ Custom.componentType = namedtype.NamedTypes(
 )
 
 
-class Keyid(BinaryData):
+class Keyid(OctetString):
     pass
 
 
@@ -304,10 +286,9 @@ class Signature(univ.Sequence):
 
 
 Signature.componentType = namedtype.NamedTypes(
-    namedtype.NamedType('keyid', Keyid().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
-    namedtype.NamedType('method', SignatureMethod().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
-    namedtype.NamedType('value', BinaryData().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 2)))
-)
+    namedtype.NamedType('keyid', Keyid()),
+    namedtype.NamedType('method', SignatureMethod()),
+    namedtype.NamedType('value', OctetString()))
 
 
 class Signatures(univ.SequenceOf):
@@ -400,9 +381,9 @@ class PublicKey(univ.Sequence):
 
 
 PublicKey.componentType = namedtype.NamedTypes(
-    namedtype.NamedType('publicKeyid', Keyid().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 0))),
-    namedtype.NamedType('publicKeyType', PublicKeyType().subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))),
-    namedtype.NamedType('publicKeyValue', BinaryData().subtype(explicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatConstructed, 2)))
+    namedtype.NamedType('publicKeyid', Keyid()),
+    namedtype.NamedType('publicKeyType', PublicKeyType()),
+    namedtype.NamedType('publicKeyValue', OctetString())
 )
 
 

--- a/tuf/encoding/root_asn1_coder.py
+++ b/tuf/encoding/root_asn1_coder.py
@@ -164,7 +164,7 @@ def set_keys(json_signed, rootPublicKeyid, timestampPublicKeyid,
   targetsPublicKey['publicKeyType'] = \
                                       int(PublicKeyType(targetsPublicKeyType))
   targetsPublicKeyValue = OctetString(
-      json_signed['keys'][targetsPublicKeyid]['keyval']['public'])
+      hexValue=json_signed['keys'][targetsPublicKeyid]['keyval']['public'])
   targetsPublicKey['publicKeyValue'] = targetsPublicKeyValue
   keys[3] = targetsPublicKey
 

--- a/tuf/encoding/root_asn1_coder.py
+++ b/tuf/encoding/root_asn1_coder.py
@@ -15,7 +15,7 @@
 """
 from __future__ import unicode_literals
 
-from pyasn1.type import univ, tag
+from pyasn1.type import tag
 
 from tuf.encoding.metadata_asn1_definitions import *
 from tuf.encoding import hex_from_octetstring
@@ -74,12 +74,12 @@ def get_json_signed(asn_metadata):
   json_keys = {}
   for i in range(4):
     publicKey = keys[i]
-    publicKeyid = hex_from_octetstring(publicKey['publicKeyid']['octetString'])
+    publicKeyid = hex_from_octetstring(publicKey['publicKeyid'])
     # Only ed25519 keys allowed for now.
     publicKeyType = int(publicKey['publicKeyType'])
     assert publicKeyType == 1
     publicKeyType = 'ed25519'
-    publicKeyValue = hex_from_octetstring(publicKey['publicKeyValue']['octetString'])
+    publicKeyValue = hex_from_octetstring(publicKey['publicKeyValue'])
     json_keys[publicKeyid] = {
       'keyid_hash_algorithms': ['sha256', 'sha512'], # TODO: <~> This was hard-coded. Fix it.
       'keytype': publicKeyType,
@@ -103,7 +103,7 @@ def get_json_signed(asn_metadata):
     topLevelRole = roles[i]
     rolename = roletype_to_rolename[int(topLevelRole['role'])]
     assert topLevelRole['numberOfKeyids'] == 1
-    keyid = hex_from_octetstring(topLevelRole['keyids'][0]['octetString'])
+    keyid = hex_from_octetstring(topLevelRole['keyids'][0])
     keyids = [keyid]
     threshold = int(topLevelRole['threshold'])
     assert threshold == 1
@@ -123,90 +123,48 @@ def set_keys(json_signed, rootPublicKeyid, timestampPublicKeyid,
 
   rootPublicKey = PublicKey()
   # NOTE: Only 1 key allowed for now!
-  keyid = Keyid().subtype(explicitTag=tag.Tag(tag.tagClassContext,
-                                              tag.tagFormatConstructed, 0))
-  keyid['octetString'] = univ.OctetString(hexValue=rootPublicKeyid)\
-                         .subtype(implicitTag=tag.Tag(tag.tagClassContext,
-                                                      tag.tagFormatSimple, 1))
+  keyid = Keyid(hexValue=rootPublicKeyid)
   rootPublicKey['publicKeyid'] = keyid
   rootPublicKeyType = json_signed['keys'][rootPublicKeyid]['keytype']
   rootPublicKey['publicKeyType'] = int(PublicKeyType(rootPublicKeyType))
-  rootPublicKeyValue = BinaryData()\
-                       .subtype(explicitTag=tag.Tag(tag.tagClassContext,
-                                                    tag.tagFormatConstructed,
-                                                    2))
-  rootPublicKeyHexString = json_signed['keys'][rootPublicKeyid]['keyval']\
-                                      ['public']
-  rootPublicKeyValue['octetString'] = \
-    univ.OctetString(hexValue=rootPublicKeyHexString)\
-    .subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))
+  rootPublicKeyValue = OctetString(
+      hexValue=json_signed['keys'][rootPublicKeyid]['keyval']['public'])
   rootPublicKey['publicKeyValue'] = rootPublicKeyValue
   keys[0] = rootPublicKey
 
   timestampPublicKey = PublicKey()
   # NOTE: Only 1 key allowed for now!
-  keyid = Keyid().subtype(explicitTag=tag.Tag(tag.tagClassContext,
-                                              tag.tagFormatConstructed, 0))
-  keyid['octetString'] = univ.OctetString(hexValue=timestampPublicKeyid)\
-                         .subtype(implicitTag=tag.Tag(tag.tagClassContext,
-                                                      tag.tagFormatSimple, 1))
+  keyid = Keyid(hexValue=timestampPublicKeyid)
   timestampPublicKey['publicKeyid'] = keyid
   timestampPublicKeyType = json_signed['keys'][timestampPublicKeyid]['keytype']
   timestampPublicKey['publicKeyType'] = \
                                       int(PublicKeyType(timestampPublicKeyType))
-  timestampPublicKeyValue = \
-                BinaryData().subtype(explicitTag=tag.Tag(tag.tagClassContext,
-                                                 tag.tagFormatConstructed, 2))
-  timestampPublicKeyHexString = json_signed['keys'][timestampPublicKeyid]\
-                                           ['keyval']['public']
-  timestampPublicKeyValue['octetString'] = \
-    univ.OctetString(hexValue=timestampPublicKeyHexString)\
-    .subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))
+  timestampPublicKeyValue = OctetString(
+      hexValue=json_signed['keys'][timestampPublicKeyid]['keyval']['public'])
   timestampPublicKey['publicKeyValue'] = timestampPublicKeyValue
   keys[1] = timestampPublicKey
 
   snapshotPublicKey = PublicKey()
   # NOTE: Only 1 key allowed for now!
-  keyid = Keyid().subtype(explicitTag=tag.Tag(tag.tagClassContext,
-                                              tag.tagFormatConstructed, 0))
-  keyid['octetString'] = univ.OctetString(hexValue=snapshotPublicKeyid)\
-                         .subtype(implicitTag=tag.Tag(tag.tagClassContext,
-                                                      tag.tagFormatSimple, 1))
+  keyid = Keyid(hexValue=snapshotPublicKeyid)
   snapshotPublicKey['publicKeyid'] = keyid
   snapshotPublicKeyType = json_signed['keys'][snapshotPublicKeyid]['keytype']
   snapshotPublicKey['publicKeyType'] = \
                                       int(PublicKeyType(snapshotPublicKeyType))
-  snapshotPublicKeyValue = \
-          BinaryData().subtype(explicitTag=tag.Tag(tag.tagClassContext,
-                                                   tag.tagFormatConstructed, 2))
-  snapshotPublicKeyHexString = json_signed['keys'][snapshotPublicKeyid]\
-                                          ['keyval']['public']
-  snapshotPublicKeyValue['octetString'] = \
-    univ.OctetString(hexValue=snapshotPublicKeyHexString)\
-    .subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))
+  snapshotPublicKeyValue = OctetString(hexValue=json_signed['keys']
+      [snapshotPublicKeyid]['keyval']['public'])
   snapshotPublicKey['publicKeyValue'] = snapshotPublicKeyValue
   keys[2] = snapshotPublicKey
 
   targetsPublicKey = PublicKey()
   # NOTE: Only 1 key allowed for now!
-  keyid = Keyid().subtype(explicitTag=tag.Tag(tag.tagClassContext,
-                                              tag.tagFormatConstructed, 0))
-  keyid['octetString'] = univ.OctetString(hexValue=targetsPublicKeyid)\
-                         .subtype(implicitTag=tag.Tag(tag.tagClassContext,
-                                                      tag.tagFormatSimple, 1))
+  keyid = Keyid(hexValue=targetsPublicKeyid)
   targetsPublicKey['publicKeyid'] = keyid
   targetsPublicKeyType = json_signed['keys'][targetsPublicKeyid]['keytype']
   targetsPublicKey['publicKeyType'] = \
                                       int(PublicKeyType(targetsPublicKeyType))
-  targetsPublicKeyValue = BinaryData()\
-                          .subtype(explicitTag=tag.Tag(tag.tagClassContext,
-                                                       tag.tagFormatConstructed,
-                                                       2))
-  targetsPublicKeyHexString = json_signed['keys'][targetsPublicKeyid]\
-                                          ['keyval']['public']
-  targetsPublicKeyValue['octetString'] = \
-    univ.OctetString(hexValue=targetsPublicKeyHexString)\
-    .subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))
+  targetsPublicKeyValue = OctetString(
+      json_signed['keys'][targetsPublicKeyid]['keyval']['public'])
   targetsPublicKey['publicKeyValue'] = targetsPublicKeyValue
   keys[3] = targetsPublicKey
 
@@ -224,10 +182,8 @@ def set_roles(json_signed, rootPublicKeyid, timestampPublicKeyid,
   rootRole['role'] = int(RoleType('root'))
   rootRoleKeyids = Keyids().subtype(implicitTag=tag.Tag(tag.tagClassContext,
                                                         tag.tagFormatSimple, 4))
-  rootRoleKeyid = Keyid()
-  rootRoleKeyid['octetString'] = \
-    univ.OctetString(hexValue=rootPublicKeyid)\
-    .subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))
+  rootRoleKeyid = Keyid(hexValue=rootPublicKeyid)
+
   # Some damned bug in pyasn1 I could not care less to fix right now.
   rootRoleKeyids.setComponentByPosition(0, rootRoleKeyid, False)
   rootRole['numberOfKeyids'] = 1
@@ -241,10 +197,8 @@ def set_roles(json_signed, rootPublicKeyid, timestampPublicKeyid,
   snapshotRoleKeyids = Keyids().subtype(implicitTag=tag.Tag(tag.tagClassContext,
                                                             tag.tagFormatSimple,
                                                             4))
-  snapshotRoleKeyid = Keyid()
-  snapshotRoleKeyid['octetString'] = \
-    univ.OctetString(hexValue=snapshotPublicKeyid)\
-    .subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))
+  snapshotRoleKeyid = Keyid(hexValue=snapshotPublicKeyid)
+
   # Some damned bug in pyasn1 I could not care less to fix right now.
   snapshotRoleKeyids.setComponentByPosition(0, snapshotRoleKeyid, False)
   snapshotRole['numberOfKeyids'] = 1
@@ -258,10 +212,8 @@ def set_roles(json_signed, rootPublicKeyid, timestampPublicKeyid,
   targetsRoleKeyids = Keyids().subtype(implicitTag=tag.Tag(tag.tagClassContext,
                                                            tag.tagFormatSimple,
                                                            4))
-  targetsRoleKeyid = Keyid()
-  targetsRoleKeyid['octetString'] = \
-    univ.OctetString(hexValue=targetsPublicKeyid)\
-    .subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))
+  targetsRoleKeyid = Keyid(hexValue=targetsPublicKeyid)
+
   # Some damned bug in pyasn1 I could not care less to fix right now.
   targetsRoleKeyids.setComponentByPosition(0, targetsRoleKeyid, False)
   targetsRole['numberOfKeyids'] = 1
@@ -275,10 +227,8 @@ def set_roles(json_signed, rootPublicKeyid, timestampPublicKeyid,
   timestampRoleKeyids = Keyids()\
                         .subtype(implicitTag=tag.Tag(tag.tagClassContext,
                                                      tag.tagFormatSimple, 4))
-  timestampRoleKeyid = Keyid()
-  timestampRoleKeyid['octetString'] = \
-    univ.OctetString(hexValue=timestampPublicKeyid)\
-    .subtype(implicitTag=tag.Tag(tag.tagClassContext, tag.tagFormatSimple, 1))
+  timestampRoleKeyid = Keyid(hexValue=timestampPublicKeyid)
+
   # Some damned bug in pyasn1 I could not care less to fix right now.
   timestampRoleKeyids.setComponentByPosition(0, timestampRoleKeyid, False)
   timestampRole['numberOfKeyids'] = 1

--- a/tuf/encoding/snapshot_asn1_coder.py
+++ b/tuf/encoding/snapshot_asn1_coder.py
@@ -221,7 +221,7 @@ def get_json_signed(asn_metadata):
     #   def translate_pyasn_enum_to_value(asn_enum_value):
     #     return asn_enum_value.namedValues[asn_enum_value][0]
     #
-    hashtype = asn_hash_info['function'].namedValues[asn_hash_info['function']][0]
+    hashtype = asn_hash_info['function'].namedValues[asn_hash_info['function']]
     hashval = hex_from_octetstring(asn_hash_info['digest'])
 
     hashes[hashtype] = hashval

--- a/tuf/encoding/snapshot_asn1_coder.py
+++ b/tuf/encoding/snapshot_asn1_coder.py
@@ -15,7 +15,7 @@
 """
 from __future__ import unicode_literals
 
-from pyasn1.type import univ, tag
+from pyasn1.type import tag
 
 from tuf.encoding.metadata_asn1_definitions import *
 from tuf.encoding import hex_from_octetstring
@@ -76,11 +76,7 @@ def get_asn_signed(pydict_signed):
         hashval = pydict_fileinfo['hashes'][hashtype]
         hash = Hash()
         hash['function'] = int(HashFunction(hashtype))
-        hash['digest'] = BinaryData().subtype(explicitTag=tag.Tag(
-            tag.tagClassContext, tag.tagFormatConstructed, 1))
-        hash['digest']['octetString'] = univ.OctetString(
-            hexValue=hashval).subtype(implicitTag=tag.Tag(
-            tag.tagClassContext, tag.tagFormatSimple, 1))
+        hash['digest'] = OctetString(hexValue=hashval)
         hashes[number_of_hashes] = hash
         number_of_hashes += 1
 
@@ -226,7 +222,7 @@ def get_json_signed(asn_metadata):
     #     return asn_enum_value.namedValues[asn_enum_value][0]
     #
     hashtype = asn_hash_info['function'].namedValues[asn_hash_info['function']][0]
-    hashval = hex_from_octetstring(asn_hash_info['digest']['octetString'])
+    hashval = hex_from_octetstring(asn_hash_info['digest'])
 
     hashes[hashtype] = hashval
 

--- a/tuf/encoding/timestamp_asn1_coder.py
+++ b/tuf/encoding/timestamp_asn1_coder.py
@@ -15,7 +15,7 @@
 """
 from __future__ import unicode_literals
 
-from pyasn1.type import univ, tag
+from pyasn1.type import tag
 
 from tuf.encoding.metadata_asn1_definitions import *
 from tuf.encoding import hex_from_octetstring
@@ -48,13 +48,7 @@ def get_asn_signed(json_signed):
   # TODO: Remove hardcoded hash assumptions here: type and number.
   # Model on code added to snapshotmetadata.py
   hash['function'] = int(HashFunction('sha256'))
-  digest = BinaryData().subtype(explicitTag=tag.Tag(tag.tagClassContext,
-                                                    tag.tagFormatConstructed,
-                                                    1))
-  octetString = univ.OctetString(hexValue=meta['hashes']['sha256'])\
-                .subtype(implicitTag=tag.Tag(tag.tagClassContext,
-                                             tag.tagFormatSimple, 1))
-  digest['octetString'] = octetString
+  digest = OctetString(hexValue=meta['hashes']['sha256'])
   hash['digest'] = digest
   hashes[0] = hash
   timestampMetadata['hashes'] = hashes
@@ -88,7 +82,7 @@ def get_json_signed(asn_metadata):
   timestampMetadata = asn_signed['body']['timestampMetadata']
   filename = str(timestampMetadata['filename'])
   # TODO: Remove hardcoded hash assumptions here.
-  sha256 = hex_from_octetstring(timestampMetadata['hashes'][0]['digest']['octetString'])
+  sha256 = hex_from_octetstring(timestampMetadata['hashes'][0]['digest'])
   json_signed['meta'] = {
     filename : {
       'hashes': {


### PR DESCRIPTION
### Purpose
The primary purpose of this pull request is to make this TUF fork compatible with modern versions of pyasn1. Currently, we have the dependency pinned at 0.2.2, from early 2017; versions >=0.2.3 
(up to the current 0.4.4) break Uptane's current TUF fork. It also serves to simplify the ASN.1 code slightly.

### Changes
- change to the way pyasn1's namedValues / enumerations are dereferenced due to a change in pyasn 0.2.3 that breaks the old way they are used
- removal of an abstraction layer (BinaryData) in the ASN.1 definitions that previously stood in for either BitStrings or OctetStrings. The code handling this additional layer broke in pyasn1 >= 0.2.3, and when it wasn't easily fixed, I removed it because it served no purpose for us -- since we ended up not needing BitStrings -- and just added more complexity. Anything that was previously BinaryData containing an OctetString (or, unused, a BitString) is now just an OctetString. 
- minor simplification: removal of some tag constraints and consequent .subtype() calls (to match asn1 definitions) didn't seem necessary and proved sensitive to changes in pyasn1 versions 


The first commit here is very similar to the first in an Uptane project [PR](https://github.com/uptane/uptane/pull/140) accomplishing the same goal for Uptane's ASN1 code (client metadata and timeserver metadata).

