### PR TITLE
Update and reorder dependencies, and add pyasn1 dependency

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -2,9 +2,6 @@
 # development, and installation.  It can be executed as follows:
 # $ pip install --requirement dev-requirements.txt
 # 
-# pip install TUF (minimal install) in editable mode (i.e., setuptools
-# "develop mode").  The current working directory must contain 'setup.py'.
---editable .
 
 # Install PyNaCl for generation and verification of ed25519 keys and signatures.
 # It also includes protection against side-channel attacks.
@@ -17,9 +14,14 @@
 # http://nvie.com/posts/pin-your-packages/
 cffi==1.7.0
 pycrypto==2.6.1
-pynacl==1.0.1
-cryptography==1.4.0
+pynacl==1.2.0
+cryptography==2.1.4
+pyasn1==0.2.2
 
 # Testing requirements.  The rest of the testing dependencies available in
 # 'tox.ini'
-tox
+tox==2.9.1
+
+# pip install TUF (minimal install) in editable mode (i.e., setuptools
+# "develop mode").  The current working directory must contain 'setup.py'.
+--editable .

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ six
 iso8601
 coverage
 coveralls
+pyasn1==0.2.2


### PR DESCRIPTION
Update and reorder dependencies, and add pyasn1 dependency.

pyasn1 was considered optional for this fork, but the fact that this
branch depends on pyasn1 being pinned at 0.2.2 (this is fixed in
branch `refine_asn1_code_tuf`) means that the dependency should
really be listed in the requirements files.

Also make sure that `pip install -e .` comes *after* the listed
dependencies.