### PR TITLE
Better ASN.1/DER encoding tests

### DIFF
--- a/tests/repository_data/uptane_mainrepo_targets_minimal.json
+++ b/tests/repository_data/uptane_mainrepo_targets_minimal.json
@@ -1,0 +1,20 @@
+{
+ "signatures": [
+  {
+   "keyid": "c24b457b2ca4b3c2f415efdbbebb914a0d05c5345b9889bda044362589d6f596",
+   "method": "ed25519",
+   "sig": "398cb53d34dcdda7b01ee363c42bab7fe1c82b222296de06236dbce280ce1ffd059143fff80efb5da02c0e96e2a20ae108ade9665a35965ac93934c9ddacdf07"
+  }
+ ],
+ "signed": {
+  "_type": "Targets",
+  "delegations": {
+   "keys": {},
+   "roles": []
+  },
+  "expires": "2037-05-16T17:49:09Z",
+  "targets": {
+  },
+  "version": 1
+ }
+}

--- a/tests/repository_data/uptane_mainrepo_targets_no_delegations.json
+++ b/tests/repository_data/uptane_mainrepo_targets_no_delegations.json
@@ -1,0 +1,69 @@
+{
+ "signatures": [
+  {
+   "keyid": "c24b457b2ca4b3c2f415efdbbebb914a0d05c5345b9889bda044362589d6f596",
+   "method": "ed25519",
+   "sig": "398cb53d34dcdda7b01ee363c42bab7fe1c82b222296de06236dbce280ce1ffd059143fff80efb5da02c0e96e2a20ae108ade9665a35965ac93934c9ddacdf07"
+  }
+ ],
+ "signed": {
+  "_type": "Targets",
+  "delegations": {
+   "keys": {},
+   "roles": []
+  },
+  "expires": "2037-05-16T17:49:09Z",
+  "targets": {
+   "/BCU1.0.txt": {
+    "hashes": {
+     "sha256": "fb0aa5699a4e7b68009fed6b094ecb00c3ad5670921be1b902b72a23cd4675b1",
+     "sha512": "0b0bb00bccf7bdad519d0a0af2794c945bd51ebdbc79f9616f0e3903b32f4ce2d5b250ab1bc2d34194bacf720b4f0aed361ef8d59ac72b1bc19e3a223a5e87cd"
+    },
+    "length": 15
+   },
+   "/BCU1.1.txt": {
+    "hashes": {
+     "sha256": "1eb6fa5c6bb606c5326d6ef0ff05f5fcefde4e50c7daea530978090778b38bf4",
+     "sha512": "9727058c2ba828fdd2fc5ae02f52c10e47404283f92df3539989e2ada3cf7e85a9772faed1bd0bad3fc2bd8f6e5d15b976b8e832dd46874be72b994bc57a62a0"
+    },
+    "length": 18
+   },
+   "/BCU1.2.txt": {
+    "hashes": {
+     "sha256": "42914dc1509923fc83b6945cbaaec193a22077ae3bb799e84b900570715fcb5a",
+     "sha512": "f213f63b79b05e3ea2045ffe198ab75a993ca5b2709a2e1eac5f18a1a6be1b5eb6af9964b78d388b404414e296b046228f9b68eb75db684eed75b509518a77a5"
+    },
+    "length": 18
+   },
+   "/INFO1.0.txt": {
+    "hashes": {
+     "sha256": "e116d4ef5a2f2dbba9a61970a25cab3e6695418e3dbfa71071e4d07aebb1f083",
+     "sha512": "7cfa230b2ad2290d38d0da9f0320c1de0dcc9acc40a74154d8f6461c9acb63e7a41a34034b6d84fed6220e1a42afbaa0846efcfc85e1d83c5174f1f8d88d2694"
+    },
+    "length": 18
+   },
+   "/TCU1.0.txt": {
+    "hashes": {
+     "sha256": "c0f997636d40ef418697e85add2e3e6f994592de0c4d90ffe0f86e177281b0dc",
+     "sha512": "87e3d4f40b43f457e507c81e0caa306893ecf4eb65c28a8ef4a5e5e66323c460c500a7cb9489221eb8bcd2eb5b7e848dcf8c631518289fa07e629c4ffcf8e686"
+    },
+    "length": 16
+   },
+   "/TCU1.1.txt": {
+    "hashes": {
+     "sha256": "56d7cd56a85e34e40d005e1f79c0e95d6937d5528ac0b301dbe68d57e03a5c21",
+     "sha512": "94d7419b8606103f363aa17feb875575a978df8e88038ea284ff88d90e534eaa7218040384b19992cc7866f5eca803e1654c9ccdf3b250d6198b3c4731216db4"
+    },
+    "length": 17
+   },
+   "/TCU1.2.txt": {
+    "hashes": {
+     "sha256": "fbc8fa01df33f30833428be0fb20edfaafa444ed23d020e3cbc9c60cff167288",
+     "sha512": "c7c3924d33804eca1d691c5fe61bb965646bf9b6225ce1f040dcde81ce0fc26f4be323f4995e0dee35a847fdbb6efe5a8c8e248e07d1728af0b4cc6fb3179d38"
+    },
+    "length": 17
+   }
+  },
+  "version": 1
+ }
+}

--- a/tests/test_asn1_codec.py
+++ b/tests/test_asn1_codec.py
@@ -30,46 +30,298 @@ class TestASN1Conversion(unittest.TestCase):
         private_key_fname, 'password')
 
 
+
   # THIS NEXT TEST fails because the TUF root.json test file in question here
   # uses an RSA key, which the ASN1 conversion does not yet support.
-  # TODO: <~> FIX.
+  # TODO: FIX.
   # Our ASN1 conversion doesn't seem to support RSA keys. In particular, it is
   # being assumed that the key values are hex strings ('f9ac1325...') but an
   # RSA public key value is e.g. '-----BEGIN PUBLIC
   # KEY------\nMIIBojANBgk...\n...'
   @unittest.expectedFailure
-  def test_1_root_partial_convert(self):
-    # Test 1: only_signed conversion PyDict -> ASN1 BER of Root
-    partial_der_conversion_tester(
+  def test_1asn_convert_root(self):
+    """
+    Test ASN.1-only conversion for a Root role from the old TUF sample data.
+    """
+    asn1_pydict_conversion_tester(
         'repository_data/repository/metadata/root.json', self)
 
 
 
-  def test_2_tuf_sample_timestamp_partial_convert(self):
-    """Test 2: only_signed conversion PyDict -> ASN1 BER of Timestamp"""
-    partial_der_conversion_tester(
+  # THIS NEXT TEST fails because the TUF root.json test file in question here
+  # uses an RSA key, which the ASN1 conversion does not yet support.
+  # TODO: FIX.
+  # Our ASN1 conversion doesn't seem to support RSA keys. In particular, it is
+  # being assumed that the key values are hex strings ('f9ac1325...') but an
+  # RSA public key value is e.g. '-----BEGIN PUBLIC
+  # KEY------\nMIIBojANBgk...\n...'
+  @unittest.expectedFailure
+  def test_1der_convert_root_tuf(self):
+    """
+    Test ASN.1 conversions with DER encoding for a Root role from the old TUF
+    sample data.
+    """
+    der_conversion_tester(
+        'repository_data/repository/metadata/root.json', self)
+
+
+
+  def test_2asn_convert_root_uptane(self):
+    """
+    Test ASN.1-only conversion for Root roles from the Uptane samples.
+    """
+    asn1_pydict_conversion_tester(
+        'repository_data/uptane_mainrepo_root.json', self)
+
+    asn1_pydict_conversion_tester(
+        'repository_data/uptane_director_root.json', self)
+
+
+  def test_2der_convert_root_uptane(self):
+    """
+    Test ASN.1 conversions with DER encoding for Root roles from the Uptane
+    samples.
+    """
+    der_conversion_tester(
+        'repository_data/uptane_mainrepo_root.json', self)
+    der_conversion_tester(
+        'repository_data/uptane_director_root.json', self)
+
+
+
+  def test_3asn_convert_timestamp_tuf(self):
+    """
+    Test ASN.1-only conversion for a Timestamp role from the old TUF sample
+    data.
+    """
+    asn1_pydict_conversion_tester(
         'repository_data/repository/metadata/timestamp.json', self)
 
 
 
-  def test_3_snapshot_partial_convert(self):
-    # Test 3: only_signed conversion PyDict -> ASN1 BER of Snapshot
-    partial_der_conversion_tester(
+  def test_3der_convert_timestamp_tuf(self):
+    """
+    Test ASN.1 conversions with DER encoding for a Timestamp role from the old
+    TUF sample data.
+    """
+    der_conversion_tester(
+        'repository_data/repository/metadata/timestamp.json', self)
+
+
+
+  def test_4asn_convert_timestamp_uptane(self):
+    """
+    Test ASN.1-only conversion for Timestamp roles from Uptane sample data.
+    """
+    asn1_pydict_conversion_tester(
+        'repository_data/uptane_mainrepo_timestamp.json', self)
+
+    asn1_pydict_conversion_tester(
+        'repository_data/uptane_director_timestamp.json', self)
+
+
+  def test_4der_convert_timestamp_uptane(self):
+    """
+    Test ASN.1 conversions with DER encoding for Timestamp roles from Uptane
+    sample data.
+    """
+    der_conversion_tester(
+        'repository_data/uptane_mainrepo_timestamp.json', self)
+
+    der_conversion_tester(
+        'repository_data/uptane_director_timestamp.json', self)
+
+
+
+  def test_5asn_convert_snapshot_tuf(self):
+    """
+    Test ASN.1-only conversion for a Snapshot role from the old TUF sample
+    data.
+    """
+    asn1_pydict_conversion_tester(
         'repository_data/repository/metadata/snapshot.json', self)
 
 
 
-  def test_4_simple_targets_partial_convert(self):
-    """Test 4: only_signed conversion PyDict -> ASN1 BER of simple Targets"""
-    partial_der_conversion_tester(
+  def test_5der_convert_snapshot_tuf(self):
+    """
+    Test ASN.1 conversions with DER encoding for a Snapshot role from the old
+    TUF sample data.
+    """
+    der_conversion_tester(
+        'repository_data/repository/metadata/snapshot.json', self)
+
+
+
+  def test_6asn_convert_snapshot_uptane(self):
+    """
+    Test ASN.1-only conversion for Snapshot roles from Uptane samples.
+    """
+    asn1_pydict_conversion_tester(
+        'repository_data/uptane_mainrepo_snapshot.json', self)
+
+    asn1_pydict_conversion_tester(
+        'repository_data/uptane_director_snapshot.json', self)
+
+
+  def test_6asn_convert_snapshot_uptane(self):
+    """
+    Test ASN.1 conversions with DER encoding for Snapshot roles from Uptane
+    samples.
+    """
+    der_conversion_tester(
+        'repository_data/uptane_mainrepo_snapshot.json', self)
+
+    der_conversion_tester(
+        'repository_data/uptane_director_snapshot.json', self)
+
+
+
+  def test_7asn_convert_targets_minimal(self):
+    """
+    Test ASN.1-only conversion for a Targets role that contains no delegations
+    and specifies no targets. This comes from Uptane sample metadata.
+    """
+    asn1_pydict_conversion_tester(
+        'repository_data/uptane_mainrepo_targets_minimal.json', self)
+
+
+
+  def test_7der_convert_targets_minimal(self):
+    """
+    Test ASN.1 conversions with DER encoding for a Targets role that contains
+    no delegations and specifies no targets. This comes from Uptane sample
+    metadata.
+    """
+    der_conversion_tester(
+        'repository_data/uptane_mainrepo_targets_minimal.json', self)
+
+
+
+  def test_8asn_convert_targets_no_delegations(self):
+    """
+    Test ASN.1-only conversion for Targets roles that contain no delegations but
+    which specify targets. These come from Uptane sample metadata.
+    """
+    asn1_pydict_conversion_tester(
+        'repository_data/uptane_mainrepo_targets_no_delegations.json', self)
+
+    asn1_pydict_conversion_tester(
+        'repository_data/uptane_director_targets.json', self)
+
+
+
+  def test_8der_convert_targets_no_delegations(self):
+    """
+    Test ASN.1 conversion with DER encoding for Targets roles that contain no
+    delegations but which specify targets. These come from Uptane sample
+    metadata.
+    """
+    der_conversion_tester(
+        'repository_data/uptane_mainrepo_targets_no_delegations.json', self)
+
+    der_conversion_tester(
+        'repository_data/uptane_director_targets.json', self)
+
+
+
+  @unittest.expectedFailure
+  # THIS NEXT TEST fails because the provided targets role includes delegations,
+  # and the current ASN.1 conversion code does not support delegations (and
+  # must be updated to do so).
+  def test_9asn_convert_targets_no_targetinfo(self):
+    """
+    Test ASN.1-only conversion for a Targets role that contains delegations
+    but specifies no targets.
+    """
+    asn1_pydict_conversion_tester(
         'repository_data/targets_simpler.json', self)
 
 
 
-  def test_5_delegated_partial_convert(self):
-    """Test 5: only_signed conversion PyDict -> ASN1 BER of delegated role"""
-    partial_der_conversion_tester(
+  @unittest.expectedFailure
+  # THIS NEXT TEST fails because the provided targets role includes delegations,
+  # and the current ASN.1 conversion code does not support delegations (and
+  # must be updated to do so).
+  def test_9der_convert_targets_no_targetinfo(self):
+    """
+    Test ASN.1 conversions with DER encoding for a Targets role that contains
+    delegations but specifies no targets.
+    """
+    der_conversion_tester(
+        'repository_data/targets_simpler.json', self)
+
+
+
+  @unittest.expectedFailure
+  # THIS NEXT TEST FAILS because the provided targets role includes delegations,
+  # and the current ASN.1 conversion code does not support delegations (and
+  # must be updated to do so).
+  def test_10asn_convert_targets(self):
+    """
+    Test ASN.1-only conversion for a Targets role containing delegations and
+    specifying targets. This comes from Uptane sample metadata.
+    """
+    asn1_pydict_conversion_tester(
+        'repository_data/uptane_mainrepo_targets.json', self)
+    # No delegations for the Director, so no Director test case.
+
+
+
+  @unittest.expectedFailure
+  # THIS NEXT TEST FAILS because the provided targets role includes delegations,
+  # and the current ASN.1 conversion code does not support delegations (and
+  # must be updated to do so).
+  def test_10der_convert_targets(self):
+    """
+    Test ASN.1 conversions with DER encoding for a Targets role containing
+    delegations and specifying targets. This comes from Uptane sample metadata.
+    """
+    der_conversion_tester(
+        'repository_data/uptane_mainrepo_targets.json', self)
+    # No delegations for the Director, so no Director test case.
+
+
+
+  def test_11asn_convert_delegated_targets(self):
+    """
+    Test ASN.1-only conversion for a delegated Targets role (from an old TUF
+    set of sample data).
+    """
+    asn1_pydict_conversion_tester(
         'repository_data/repository/metadata/role1.json', self)
+
+
+
+  def test_11der_convert_delegated_targets(self):
+    """
+    Test ASN.1 conversions with DER encoding for a delegated Targets role (from
+    an old TUF set of sample data).
+    """
+    der_conversion_tester(
+        'repository_data/repository/metadata/role1.json', self)
+
+
+
+  def test_12asn_convert_delegated_targets_uptane(self):
+    """
+    Test ASN.1-only conversion for a delegated Targets role from Uptane sample
+    data.
+    """
+    asn1_pydict_conversion_tester(
+        'repository_data/uptane_mainrepo_role1.json', self)
+    # No delegations for the Director, so no Director test case.
+
+
+
+  def test_12der_convert_delegated_targets_uptane(self):
+    """
+    Test ASN.1 conversions with DER encoding for a delegated Targets role from
+    Uptane sample data.
+    """
+    der_conversion_tester(
+        'repository_data/uptane_mainrepo_role1.json', self)
+    # No delegations for the Director, so no Director test case.
 
 
 
@@ -83,63 +335,33 @@ class TestASN1Conversion(unittest.TestCase):
   # string regardless of its type and covert it to ASN1 with the name
   # preserved, in a dict of some sort....
   @unittest.expectedFailure
-  def test_6_targets_w_custom_partial_convert(self):
-    """Test 5: only_signed conversion PyDict -> ASN1 BER of Targets"""
-    partial_der_conversion_tester(
+  def test_13asn_convert_targets_with_custom(self):
+    """
+    Test ASN.1-only conversion for a Targets role that contains an unexpected
+    custom parameter. (This is permitted by the spec.)
+    """
+    asn1_pydict_conversion_tester(
         'repository_data/repository/metadata/targets.json', self)
 
 
 
-
-
-  def test_11_root_uptane_partial_convert(self):
-    """Test 11: only_signed conversion PyDict -> ASN1 BER of Root"""
-    partial_der_conversion_tester(
-        'repository_data/uptane_mainrepo_root.json', self)
-    partial_der_conversion_tester(
-        'repository_data/uptane_director_root.json', self)
-
-
-
-  def test_12_snapshot_uptane_partial_convert(self):
-    """Test 12: only_signed conversion PyDict -> ASN1 BER of Snapshot"""
-    partial_der_conversion_tester(
-        'repository_data/uptane_mainrepo_snapshot.json', self)
-    partial_der_conversion_tester(
-        'repository_data/uptane_director_snapshot.json', self)
-
-
-
-  def test_13_timestamp_uptane_partial_convert(self):
-    """Test 13: only_signed conversion PyDict -> ASN1 BER of Snapshot"""
-    partial_der_conversion_tester(
-        'repository_data/uptane_mainrepo_snapshot.json', self)
-    partial_der_conversion_tester(
-        'repository_data/uptane_director_snapshot.json', self)
-
-
-
-  def test_14_targets_uptane_partial_convert(self):
-    """Test 14: only_signed conversion PyDict -> ASN1 BER of Targets"""
-    partial_der_conversion_tester(
-        'repository_data/uptane_mainrepo_targets.json', self)
-    partial_der_conversion_tester(
-        'repository_data/uptane_director_targets.json', self)
-
-
-
-  def test_15_delegated_uptane_partial_convert(self):
-    """Test 15: only_signed conversion PyDict -> ASN1 BER of Snapshot"""
-    partial_der_conversion_tester(
-        'repository_data/uptane_mainrepo_role1.json', self)
-    # No delegations for the Director, so no second case to test.
-
-
-
-
-
-
-
+  # THIS NEXT TEST fails because the TUF targets.json test file used here
+  # uses a custom parameter that the ASN1 conversion does not yet support,
+  # specifically 'file_permissions'.
+  # TODO: <~> FIX. In order to be TUF compliant, ASN.1 metadata has to be
+  # able to take arbitrary custom key-value pairs.
+  # Targets custom data can be arbitrary. The targetsmetadata.py converter does
+  # not support that and has to. It'll need to treat everything it's given as a
+  # string regardless of its type and covert it to ASN1 with the name
+  # preserved, in a dict of some sort....
+  @unittest.expectedFailure
+  def test_13der_convert_targets_with_custom(self):
+    """
+    Test ASN.1 conversions with DER encoding for a Targets role that contains
+    an unexpected custom parameter. (This is permitted by the spec.)
+    """
+    der_conversion_tester(
+        'repository_data/repository/metadata/targets.json', self)
 
 
 


### PR DESCRIPTION
Improved ASN.1/DER conversion testing for (somewhat...) easier debugging and perhaps test-driven development on the refactoring I'm attempting:

- Test asn1 conversion without DER encoding by converting from a JSON-compatible dictionary to a pyasn1-compatible dictionary and back, and comparing the original to the result.
- Improve comments / docstrings
- Better test DER encoding and re-signing by performing signature checks when testing the re-signing functionality
- Reorganize test functions to simplify debugging
- Add a few more test cases (no delegations and no targetinfo in Targets, delegations but no targetinfo in Targets...)


(For reviewers: note that you'd run this test by installing this TUF fork, stepping into the tests directory, and running `python test_asn1_codec.py`)