### PR TITLE
Update two tests to match changes made to Uptane's TUF fork

### DIFF
--- a/tests/test_mix_and_match_attack.py
+++ b/tests/test_mix_and_match_attack.py
@@ -253,6 +253,12 @@ class TestMixAndMatchAttack(unittest_toolbox.Modified_TestCase):
     self.repository_updater.refresh()
 
     try:
+      # Update or load the trusted Targets role metadata, in order to make sure
+      # we've retrieved info about the expected keys for delegated targets role
+      # 'role1'.
+      self.repository_updater.targets_of_role('targets')
+      # Now try updating and validating metadata role role1, expecting a
+      # BadVersionNumberError.
       self.repository_updater.targets_of_role('role1')
    
     # Verify that the specific 'tuf.BadVersionNumberError' exception is raised

--- a/tests/test_repository_lib.py
+++ b/tests/test_repository_lib.py
@@ -859,7 +859,7 @@ class TestRepositoryToolFunctions(unittest.TestCase):
     # duplicates are removed.  create_signature() generates a key for the
     # key type of the first argument (i.e., root_rsa_key).
     new_pss_signature = tuf.keys.create_signature(root_rsa_key,
-                                                  root_signable['signed'])
+        tuf.formats.encode_canonical(root_signable['signed']).encode('utf-8'))
     root_signable['signatures'].append(new_pss_signature)
 
     expected_number_of_signatures = len(root_signable['signatures'])


### PR DESCRIPTION
test_repository_lib fix:
Some time ago in PR https://github.com/awwad/tuf/pull/5
I changed signature code such that tuf.keys.create_signature
and verify_signature accept already-encoded bytes instead of
assuming what the encodings should look like, and moved
encoding up a bit in the stack (often to tuf.sig). This
test wasn't updated at that point, and now it is being
updated to deal with this (by encoding first, then calling
the tuf.keys.create_signature function).

test_mix_and_match_attack fix:
A fix to the way that role files are retained if validation
fails (possibly from https://github.com/awwad/tuf/pull/13)
broke this test, I think, though I'm not certain. In any
event, this demonstrates passable behavior for now, with the
role info loaded correctly.

These tests in the TUF fork are not regarded as critical,
given that testing occurs at the Uptane level and Uptane will
be migrating to the main TUF repository when possible;
however, these fixes may be helpful in the interim.