### PR TITLE
Fix test_key_revocation's root key revocation test

### DIFF
--- a/tests/test_key_revocation.py
+++ b/tests/test_key_revocation.py
@@ -397,8 +397,6 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
     # Root's version number = 2 after the following write().
     repository.write()
     
-    import time; time.sleep(0.1) # Allow files time to copy.
-
     # Move the staged metadata to the "live" metadata.
     shutil.rmtree(os.path.join(self.repository_directory, 'metadata'))
     shutil.copytree(os.path.join(self.repository_directory, 'metadata.staged'),
@@ -430,8 +428,6 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
     shutil.copytree(os.path.join(self.repository_directory, 'metadata.staged'),
                     os.path.join(self.repository_directory, 'metadata'))
 
-    import time; time.sleep(0.1) # Allow files time to copy.
-    
     # Root's version number = 3...
     # The client successfully performs a refresh of top-level metadata to get
     # the latest changes.
@@ -452,8 +448,6 @@ class TestKeyRevocation(unittest_toolbox.Modified_TestCase):
     shutil.rmtree(os.path.join(self.repository_directory, 'metadata'))
     shutil.copytree(os.path.join(self.repository_directory, 'metadata.staged'),
                     os.path.join(self.repository_directory, 'metadata'))
-
-    import time; time.sleep(0.1) # Allow files time to copy.
 
     # Root's version number = 4...
     self.repository_updater.refresh() 


### PR DESCRIPTION
Fix test_key_revocation's root key revocation test, which I think was not correct / unfinished at the time of this repository's forking. It makes sense now:

Three-part test:
1. Revoke the old root key (the only key at the time), add a new root key, and try updating. Client will reject because client expects only the old key.
2. Sign with the old key in addition to the new key. Client should accept and revoke the old key.
3. Sign with only the new key. Client should accept.

(Sidenote: this test covers the scenario in which there is one root key, where there is a race to revoke and replace if compromise occurs. The test doesn't test multiple root keys, which is a simpler scenario but probably still bears a test being written for it.)