### PR TITLE
Replace use of pyasn1's OctetString.prettyPrint() function

### DIFF
--- a/tests/test_asn1_codec.py
+++ b/tests/test_asn1_codec.py
@@ -14,6 +14,7 @@ import tuf.encoding.snapshot_asn1_coder as snapshot_asn1_coder
 import tuf.encoding.timestamp_asn1_coder as timestamp_asn1_coder
 import tuf.encoding.targets_asn1_coder as targets_asn1_coder
 import tuf.encoding.metadata_asn1_definitions as metadata_asn1_spec
+from tuf.encoding import hex_from_octetstring
 
 import tuf.keys
 import hashlib
@@ -28,6 +29,19 @@ class TestASN1Conversion(unittest.TestCase):
 
     cls.test_signing_key = repo_tool.import_ed25519_privatekey_from_file(
         private_key_fname, 'password')
+
+
+  def test_hex_from_octetstring(self):
+
+    original_hex_str = '5f1a1354'
+
+    octet_str = metadata_asn1_spec.OctetString(hexValue=original_hex_str)
+
+    hex_str = hex_from_octetstring(octet_str)
+
+    self.assertEqual(original_hex_str, hex_str)
+
+    # TODO: Add some more tests using key data.
 
 
 

--- a/tuf/asn1_codec.py
+++ b/tuf/asn1_codec.py
@@ -14,6 +14,8 @@ import tuf.formats
 import logging
 import hashlib
 
+from tuf.encoding import hex_from_octetstring
+
 # See 'log.py' to learn how logging is handled in TUF.
 logger = logging.getLogger('tuf.asn1_codec')
 
@@ -139,14 +141,10 @@ def convert_signed_der_to_dersigned_json(der_data):
 
   for asn_signature in asn_signatures:
     json_signatures.append({
-        # Next lines are not ideal: prettyPrint and having to manually skip the
-        # first two characters (which we expect to be '0x' indicating a hex
-        # string). See if there's a better method of converting from the
-        # octetString to what TUF expects.
-        'keyid': asn_signature['keyid']['octetString'].prettyPrint()[2:],
+        'keyid': hex_from_octetstring(asn_signature['keyid']['octetString']),
         # TODO: See if it's possible to tweak the definition of 'method' so that str(method) returns what we want rather here than the enum, so that we don't have to do make this weird enum translation call?
         'method': asn_signature['method'].namedValues[asn_signature['method']._value][0], #str(asn_signature['method']),
-        'sig': asn_signature['value']['octetString'].prettyPrint()[2:]})
+        'sig': hex_from_octetstring(asn_signature['value']['octetString'])})
 
   return {'signatures': json_signatures, 'signed': json_signed}
 

--- a/tuf/encoding/__init__.py
+++ b/tuf/encoding/__init__.py
@@ -1,0 +1,45 @@
+"""
+<Program Name>
+  __init__.py  (for tuf/encoding)
+
+<Copyright>
+  See LICENSE for licensing information.
+
+<Purpose>
+  Provide common functions and constants for ASN.1 encoding code.
+"""
+
+# Help with Python 3 compatibility, where the print statement is a function, an
+# implicit relative import is invalid, and the '/' operator performs true
+# division.  Example:  print 'hello world' raises a 'SyntaxError' exception.
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import tuf
+import tuf.formats
+
+
+def hex_from_octetstring(octetstring):
+  """
+  Convert a pyasn1 OctetString object into a hex string.
+  Example return:   '4b394ae2'
+  Raises Error() if an individual octet's supposed integer value is out of
+  range (0 <= x <= 255).
+  """
+  octets = octetstring.asNumbers()
+  hex_string = ''
+
+  for x in octets:
+    if x < 0 or x > 255:
+      raise tuf.Error('Unable to generate hex string from OctetString: integer '
+          'value of octet provided is not in range: ' + str(x))
+    hex_string += '%.2x' % x
+
+  # Make sure that the resulting value is a valid hex string.
+  tuf.formats.HEX_SCHEMA.check_match(hex_string)
+  if '\\x' in str(hex_string):
+    print(hex_string)
+    import pdb; pdb.set_trace()
+    print()
+
+  return hex_string

--- a/tuf/encoding/root_asn1_coder.py
+++ b/tuf/encoding/root_asn1_coder.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 from pyasn1.type import univ, tag
 
 from tuf.encoding.metadata_asn1_definitions import *
+from tuf.encoding import hex_from_octetstring
 
 import calendar
 from datetime import datetime #import datetime
@@ -73,16 +74,12 @@ def get_json_signed(asn_metadata):
   json_keys = {}
   for i in range(4):
     publicKey = keys[i]
-    publicKeyid = publicKey['publicKeyid']['octetString'].prettyPrint()
-    assert publicKeyid.startswith('0x')
-    publicKeyid = publicKeyid[2:]
+    publicKeyid = hex_from_octetstring(publicKey['publicKeyid']['octetString'])
     # Only ed25519 keys allowed for now.
     publicKeyType = int(publicKey['publicKeyType'])
     assert publicKeyType == 1
     publicKeyType = 'ed25519'
-    publicKeyValue = publicKey['publicKeyValue']['octetString'].prettyPrint()
-    assert publicKeyValue.startswith('0x')
-    publicKeyValue = publicKeyValue[2:]
+    publicKeyValue = hex_from_octetstring(publicKey['publicKeyValue']['octetString'])
     json_keys[publicKeyid] = {
       'keyid_hash_algorithms': ['sha256', 'sha512'], # TODO: <~> This was hard-coded. Fix it.
       'keytype': publicKeyType,
@@ -106,10 +103,7 @@ def get_json_signed(asn_metadata):
     topLevelRole = roles[i]
     rolename = roletype_to_rolename[int(topLevelRole['role'])]
     assert topLevelRole['numberOfKeyids'] == 1
-    #keyids = [str(topLevelRole['keyids'][0])]
-    keyid = topLevelRole['keyids'][0]['octetString'].prettyPrint()
-    assert keyid.startswith('0x')
-    keyid = keyid[2:]
+    keyid = hex_from_octetstring(topLevelRole['keyids'][0]['octetString'])
     keyids = [keyid]
     threshold = int(topLevelRole['threshold'])
     assert threshold == 1

--- a/tuf/encoding/snapshot_asn1_coder.py
+++ b/tuf/encoding/snapshot_asn1_coder.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 from pyasn1.type import univ, tag
 
 from tuf.encoding.metadata_asn1_definitions import *
+from tuf.encoding import hex_from_octetstring
 
 import tuf.conf
 import calendar
@@ -225,13 +226,7 @@ def get_json_signed(asn_metadata):
     #     return asn_enum_value.namedValues[asn_enum_value][0]
     #
     hashtype = asn_hash_info['function'].namedValues[asn_hash_info['function']][0]
-    hashval = asn_hash_info['digest']['octetString'].prettyPrint()  # TODO: "prettyPrint()" is probably not the way to go long-term.
-
-    if not hashval.startswith('0x'):
-      raise tuf.Error('ASN1 Conversion failure for Snapshot role: Given hash '
-        'value in root role info in Snapshot for hash type ' + str(hashtype) +
-        ' does not start with "0x".')
-    hashval = hashval[2:] # Skip the '0x' header on the hash.
+    hashval = hex_from_octetstring(asn_hash_info['digest']['octetString'])
 
     hashes[hashtype] = hashval
 

--- a/tuf/encoding/targets_asn1_coder.py
+++ b/tuf/encoding/targets_asn1_coder.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 from pyasn1.type import univ, tag
 
 from tuf.encoding.metadata_asn1_definitions import *
+from tuf.encoding import hex_from_octetstring
 
 import calendar
 from datetime import datetime #import datetime
@@ -280,16 +281,12 @@ def set_json_keys(json_signed, delegations):
 
   for i in range(numberOfKeys):
     key = keys[i]
-    keyid = key['publicKeyid']['octetString'].prettyPrint() #str(key['publicKeyid'])
-    assert keyid.startswith('0x')
-    keyid = keyid[2:]
+    keyid = hex_from_octetstring(key['publicKeyid']['octetString'])
     keytype = int(key['publicKeyType'])
     # FIXME: Only ed25519 keys allowed for now.
     assert keytype == 1
     keytype = 'ed25519'
-    octetString =  key['publicKeyValue']['octetString'].prettyPrint()
-    assert octetString.startswith('0x')
-    keyval = octetString[2:]
+    keyval =  hex_from_octetstring(key['publicKeyValue']['octetString'])
     json_keys[keyid] = {
       "keyid_hash_algorithms": [
         "sha256",
@@ -374,9 +371,7 @@ def set_json_targets(json_signed, targetsMetadata):
     for j in range(numberOfHashes):
       hash = hashes[j]
       hash_function = hashenum_to_hashfunction[int(hash['function'])]
-      octetString = hash['digest']['octetString'].prettyPrint()
-      assert octetString.startswith('0x')
-      hash_value = octetString[2:]
+      hash_value = hex_from_octetstring(hash['digest']['octetString'])
       json_hashes[hash_function] = hash_value
     filemeta['hashes'] = json_hashes
 

--- a/tuf/encoding/timestamp_asn1_coder.py
+++ b/tuf/encoding/timestamp_asn1_coder.py
@@ -18,6 +18,7 @@ from __future__ import unicode_literals
 from pyasn1.type import univ, tag
 
 from tuf.encoding.metadata_asn1_definitions import *
+from tuf.encoding import hex_from_octetstring
 
 import calendar
 from datetime import datetime #import datetime
@@ -87,9 +88,7 @@ def get_json_signed(asn_metadata):
   timestampMetadata = asn_signed['body']['timestampMetadata']
   filename = str(timestampMetadata['filename'])
   # TODO: Remove hardcoded hash assumptions here.
-  sha256 = timestampMetadata['hashes'][0]['digest']['octetString'].prettyPrint() # TODO: Probably not the way to go long-term.
-  assert sha256.startswith('0x')
-  sha256 = sha256[2:]
+  sha256 = hex_from_octetstring(timestampMetadata['hashes'][0]['digest']['octetString'])
   json_signed['meta'] = {
     filename : {
       'hashes': {


### PR DESCRIPTION
### Briefly, this PR:
- Adds function `hex_from_octetstring()` to the tuf.encoding package (in __init__.py).
- Tests the new function
- Uses the new function in the various asn.1 encoding modules instead of some pyasn1 code.

### Background and Details
Part of converting TUF metadata between JSON-compatible Python dict and (py)asn1-compatible Python dict involves conversion of binary data that are stored/used as hex strings in TUF (e.g. hashes, key IDs, and key values).
We use the OctetString type in ASN.1 to serialize these pieces of data. In converting from ASN.1 ((py)asn1-compatible Python dict, tbc) back to TUF's internal representation (JSON-compatible Python dict), we previously used pyasn1's included OctetString.prettyPrint() function. That's no good, unfortunately: 
The pyasn1 code provided that yields a hex string from OctetString objects is [OctetString.prettyPrint()](https://github.com/etingof/pyasn1/blob/70d435a06ebbf6d0560bb68501d59c5e25d04a8c/pyasn1/type/univ.py#L919-L934). That has some unusual and unexpected behavior; among them:
- it sometimes prefixes '0x' to the hex string, and sometimes does not
- it can seemingly (just based on a look at the code) return an octet string instead of a hex string if any of the characters aren't interpretable as an ASCII encoding.... (This probably emerges from a compromise made by pyasn1 code intended to support an actively discouraged use of OctetStrings: to directly contain normal strings....)

As a result, I'm replacing use of OctetString.prettyPrint() with a new function that converts an OctetString object (pyasn1 object representing binary data) into a hex string. I do this by calculating the hex string value myself from the integers provided by OctetString.asNumbers().

This also has the benefit of stripping some odd code intended to deal with the prettyPrint() behaviors.