### PR TITLE
Allow a TUF client to override the system clock

### DIFF
--- a/tuf/client/updater.py
+++ b/tuf/client/updater.py
@@ -2883,9 +2883,10 @@ class SingleRepoUpdater(object):
     # If the current time has surpassed the expiration date, raise
     # an exception.  'expires' is in 'tuf.formats.ISO8601_DATETIME_SCHEMA'
     # format (e.g., '1985-10-21T01:22:00Z'.)  Convert it to a unix timestamp and
-    # compare it against the current time.time() (also in Unix/POSIX time
-    # format, although with microseconds attached.)
-    current_time = int(time.time())
+    # compare it against the current time from tuf.util.get_current_time(),
+    # which is also in Unix/POSIX time format, and allows manual override of
+    # the system clock.)
+    current_time = tuf.util.get_current_time()
 
     # Generate a user-friendly error message if 'expires' is less than the
     # current time (i.e., a local time.)

--- a/tuf/conf.py
+++ b/tuf/conf.py
@@ -149,3 +149,10 @@ SUPPORTED_URI_SCHEMES = ['http', 'https', 'file']
 
 # By default, limit number of delegatees we visit for any target.
 MAX_NUMBER_OF_DELEGATIONS = 2**5
+
+
+# To override use of the system clock and use a fixed, trusted time value,
+# manually updated, alter CLOCK_OVERRIDE from None to an integer time
+# conforming to tuf.formats.UNIX_TIMESTAMP_SCHEMA (similar to what you would
+# get from int(time.time())).
+CLOCK_OVERRIDE = None

--- a/tuf/repository_lib.py
+++ b/tuf/repository_lib.py
@@ -750,13 +750,13 @@ def _log_warning_if_expires_soon(rolename, expires_iso8601_timestamp,
   """
  
   # Metadata stores expiration datetimes in ISO8601 format.  Convert to
-  # unix timestamp, subtract from from current time.time() (also in POSIX time)
+  # unix timestamp, subtract from current time (also in POSIX time)
   # and compare against 'seconds_remaining_to_warn'.  Log a warning message
   # to console if 'rolename' expires soon.
   datetime_object = iso8601.parse_date(expires_iso8601_timestamp)
   expires_unix_timestamp = \
     tuf.formats.datetime_to_unix_timestamp(datetime_object) 
-  seconds_until_expires = expires_unix_timestamp - int(time.time())
+  seconds_until_expires = expires_unix_timestamp - tuf.util.get_current_time()
   
   if seconds_until_expires <= seconds_remaining_to_warn:
     days_until_expires = seconds_until_expires / 86400

--- a/tuf/repository_tool.py
+++ b/tuf/repository_tool.py
@@ -622,25 +622,25 @@ class Metadata(object):
     # 1 year, 3 months, 1 week, and 1 day from the current time, respectively.
     if expires is None:
       if self.rolename == 'root':
-        expires = \
-          tuf.formats.unix_timestamp_to_datetime(int(time.time() + ROOT_EXPIRATION))
-      
+        expires = tuf.formats.unix_timestamp_to_datetime(
+            tuf.util.get_current_time() + ROOT_EXPIRATION)
+
       elif self.rolename == 'Targets':
-        expires = \
-          tuf.formats.unix_timestamp_to_datetime(int(time.time() + TARGETS_EXPIRATION))
-      
+        expires = tuf.formats.unix_timestamp_to_datetime(
+            tuf.util.get_current_time() + TARGETS_EXPIRATION)
+
       elif self.rolename == 'Snapshot':
-        expires = \
-          tuf.formats.unix_timestamp_to_datetime(int(time.time() + SNAPSHOT_EXPIRATION))
-  
+        expires = tuf.formats.unix_timestamp_to_datetime(
+            tuf.util.get_current_time() + SNAPSHOT_EXPIRATION)
+
       elif self.rolename == 'Timestamp':
-        expires = \
-          tuf.formats.unix_timestamp_to_datetime(int(time.time() + TIMESTAMP_EXPIRATION))
+        expires = tuf.formats.unix_timestamp_to_datetime(
+            tuf.util.get_current_time() + TIMESTAMP_EXPIRATION)
 
       else:
-        expires = \
-          tuf.formats.unix_timestamp_to_datetime(int(time.time() + TIMESTAMP_EXPIRATION))
-    
+        expires = tuf.formats.unix_timestamp_to_datetime(
+            tuf.util.get_current_time() + TIMESTAMP_EXPIRATION)
+
     # Is 'expires' a datetime.datetime() object?
     # Raise 'tuf.FormatError' if not.
     if not isinstance(expires, datetime.datetime):
@@ -652,9 +652,9 @@ class Metadata(object):
     expires = expires.replace(microsecond = 0)
     
     # Ensure the expiration has not already passed.
-    current_datetime = \
-      tuf.formats.unix_timestamp_to_datetime(int(time.time()))
-    
+    current_datetime = tuf.formats.unix_timestamp_to_datetime(
+        tuf.util.get_current_time())
+
     if expires < current_datetime:
       raise tuf.Error(repr(key) + ' has already expired.')
    
@@ -1255,9 +1255,9 @@ class Metadata(object):
     datetime_object = datetime_object.replace(microsecond = 0)
     
     # Ensure the expiration has not already passed.
-    current_datetime_object = \
-      tuf.formats.unix_timestamp_to_datetime(int(time.time()))
-    
+    current_datetime_object = tuf.formats.unix_timestamp_to_datetime(
+        tuf.util.get_current_time())
+
     if datetime_object < current_datetime_object:
       raise tuf.Error(repr(self.rolename) + ' has already expired.')
    
@@ -1426,8 +1426,8 @@ class Root(Metadata):
 
     # By default, 'snapshot' metadata is set to expire 1 week from the current
     # time.  The expiration may be modified.
-    expiration = \
-      tuf.formats.unix_timestamp_to_datetime(int(time.time() + ROOT_EXPIRATION))
+    expiration = tuf.formats.unix_timestamp_to_datetime(
+        tuf.util.get_current_time() + ROOT_EXPIRATION)
     expiration = expiration.isoformat() + 'Z'
 
     roleinfo = {'keyids': [], 'signing_keyids': [], 'threshold': 1, 
@@ -1491,8 +1491,8 @@ class Timestamp(Metadata):
 
     # By default, 'snapshot' metadata is set to expire 1 week from the current
     # time.  The expiration may be modified.
-    expiration = \
-      tuf.formats.unix_timestamp_to_datetime(int(time.time() + TIMESTAMP_EXPIRATION))
+    expiration = tuf.formats.unix_timestamp_to_datetime(
+        tuf.util.get_current_time() + TIMESTAMP_EXPIRATION)
     expiration = expiration.isoformat() + 'Z'
 
     roleinfo = {'keyids': [], 'signing_keyids': [], 'threshold': 1,
@@ -1550,8 +1550,8 @@ class Snapshot(Metadata):
 
     # By default, 'snapshot' metadata is set to expire 1 week from the current
     # time.  The expiration may be modified.
-    expiration = \
-      tuf.formats.unix_timestamp_to_datetime(int(time.time() + SNAPSHOT_EXPIRATION))
+    expiration = tuf.formats.unix_timestamp_to_datetime(
+        tuf.util.get_current_time() + SNAPSHOT_EXPIRATION)
     expiration = expiration.isoformat() + 'Z'
 
     roleinfo = {'keyids': [], 'signing_keyids': [], 'threshold': 1,
@@ -1648,8 +1648,8 @@ class Targets(Metadata):
   
     # By default, Targets objects are set to expire 3 months from the current
     # time.  May be later modified.
-    expiration = \
-      tuf.formats.unix_timestamp_to_datetime(int(time.time() + TARGETS_EXPIRATION))
+    expiration = tuf.formats.unix_timestamp_to_datetime(
+        tuf.util.get_current_time() + TARGETS_EXPIRATION)
     expiration = expiration.isoformat() + 'Z'
 
     # If 'roleinfo' is not provided, set an initial default.
@@ -2256,8 +2256,8 @@ class Targets(Metadata):
    
     # Create a new Targets object for the 'rolename' delegation.  An initial
     # expiration is set (3 months from the current time).
-    expiration = \
-      tuf.formats.unix_timestamp_to_datetime(int(time.time() + TARGETS_EXPIRATION))
+    expiration = tuf.formats.unix_timestamp_to_datetime(
+        tuf.util.get_current_time() + TARGETS_EXPIRATION)
     expiration = expiration.isoformat() + 'Z'
     
     roleinfo = {'name': rolename, 'keyids': keyids, 'signing_keyids': [],

--- a/tuf/util.py
+++ b/tuf/util.py
@@ -33,6 +33,7 @@ import shutil
 import logging
 import tempfile
 import fnmatch
+import time
 
 import tuf
 import tuf.hash
@@ -1168,3 +1169,20 @@ def digests_are_equal(digest1, digest2):
       are_equal = False
 
   return are_equal
+
+
+
+
+
+def get_current_time():
+  '''
+  If the clock has been overridden with some manually updated trusted time,
+  provide that.  Otherwise, provide the time in seconds (rounded down to an
+  integer) since the epoch.
+  '''
+  if tuf.conf.CLOCK_OVERRIDE is not None:
+    tuf.formats.UNIX_TIMESTAMP_SCHEMA.check_match(tuf.conf.CLOCK_OVERRIDE)
+    return tuf.conf.CLOCK_OVERRIDE
+
+  else:
+    return int(time.time())


### PR DESCRIPTION
Allow a TUF client to override the system clock to some value that they trust and will manually update.

This is of use if, say, a trusted time is periodically retrieved from some other source, and the clock will stand still until it is updated this way.  For example, Uptane has use for this functionality.